### PR TITLE
Fix docs build failures and remove Facebook icon from Team section

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30
     reviewers:
       - "evroon"
     ignore:
@@ -19,6 +21,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30
     reviewers:
       - "evroon"
     ignore:

--- a/components/HeroCards.tsx
+++ b/components/HeroCards.tsx
@@ -9,9 +9,9 @@ import {
   CardTitle,
   CardFooter,
 } from "../components/ui/card";
-import { Check, Linkedin } from "lucide-react";
+import { Check } from "lucide-react";
 import { LightBulbIcon } from "./Icons";
-import { GitHubLogoIcon } from "@radix-ui/react-icons";
+import { GitHubLogoIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
 import Image from "next/image";
 
 export const HeroCards = () => {
@@ -99,7 +99,7 @@ export const HeroCards = () => {
               })}
             >
               <span className="sr-only">Linkedin icon</span>
-              <Linkedin size="20" />
+              <LinkedInLogoIcon className="w-5 h-5" />
             </a>
           </div>
         </CardFooter>

--- a/components/Team.tsx
+++ b/components/Team.tsx
@@ -33,10 +33,6 @@ const teamList: TeamProps[] = [
         url: "https://www.linkedin.com/in/leopoldo-miranda/",
       },
       {
-        name: "Facebook",
-        url: "https://www.facebook.com/",
-      },
-      {
         name: "Instagram",
         url: "https://www.instagram.com/",
       },
@@ -50,10 +46,6 @@ const teamList: TeamProps[] = [
       {
         name: "Linkedin",
         url: "https://www.linkedin.com/in/leopoldo-miranda/",
-      },
-      {
-        name: "Facebook",
-        url: "https://www.facebook.com/",
       },
       {
         name: "Instagram",
@@ -87,8 +79,8 @@ const teamList: TeamProps[] = [
         url: "https://www.linkedin.com/in/leopoldo-miranda/",
       },
       {
-        name: "Facebook",
-        url: "https://www.facebook.com/",
+        name: "Instagram",
+        url: "https://www.instagram.com/",
       },
     ],
   },
@@ -99,19 +91,6 @@ export const Team = () => {
     switch (iconName) {
       case "Linkedin":
         return <LinkedInLogoIcon className="w-5 h-5" />;
-
-      case "Facebook":
-        return (
-          <svg
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-            className="fill-foreground w-5 h-5"
-          >
-            <title>Facebook</title>
-            <path d="M24 12.073C24 5.405 18.627 0 12 0S0 5.405 0 12.073c0 6.023 4.388 11.015 10.125 11.926v-8.437H7.078v-3.49h3.047V9.41c0-3.017 1.791-4.686 4.533-4.686 1.313 0 2.686.236 2.686.236v2.962h-1.514c-1.49 0-1.955.93-1.955 1.886v2.264h3.328l-.532 3.49h-2.796V24C19.612 23.088 24 18.096 24 12.073z" />
-          </svg>
-        );
 
       case "Instagram":
         return <InstagramLogoIcon className="w-5 h-5" />;

--- a/components/Team.tsx
+++ b/components/Team.tsx
@@ -8,7 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from "../components/ui/card";
-import { Facebook, Instagram, Linkedin } from "lucide-react";
+import { InstagramLogoIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
 
 interface TeamProps {
   imageUrl: string;
@@ -98,13 +98,23 @@ export const Team = () => {
   const socialIcon = (iconName: string) => {
     switch (iconName) {
       case "Linkedin":
-        return <Linkedin size="20" />;
+        return <LinkedInLogoIcon className="w-5 h-5" />;
 
       case "Facebook":
-        return <Facebook size="20" />;
+        return (
+          <svg
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            className="fill-foreground w-5 h-5"
+          >
+            <title>Facebook</title>
+            <path d="M24 12.073C24 5.405 18.627 0 12 0S0 5.405 0 12.073c0 6.023 4.388 11.015 10.125 11.926v-8.437H7.078v-3.49h3.047V9.41c0-3.017 1.791-4.686 4.533-4.686 1.313 0 2.686.236 2.686.236v2.962h-1.514c-1.49 0-1.955.93-1.955 1.886v2.264h3.328l-.532 3.49h-2.796V24C19.612 23.088 24 18.096 24 12.073z" />
+          </svg>
+        );
 
       case "Instagram":
-        return <Instagram size="20" />;
+        return <InstagramLogoIcon className="w-5 h-5" />;
     }
   };
 

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -24,7 +24,8 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -34,7 +34,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -48,7 +48,8 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<


### PR DESCRIPTION
This PR updates the docs site code to resolve CI/build failures and applies follow-up feedback to remove Facebook social icon code from the Team component.

### Changes made

- Fixed formatting issues in UI component files that were failing `prettier --check`.
- Replaced invalid `lucide-react` social icon imports/usages with supported icon implementations so `next build` succeeds.
- Removed Facebook social icon code from `components/Team.tsx`:
  - Removed Facebook entries from team social links data.
  - Removed Facebook icon rendering logic.

### Validation

- `yarn test-check` passes
- `yarn build` passes